### PR TITLE
fix: moving the rug tassels of the plotting function to outside

### DIFF
--- a/R/plot_methylation.R
+++ b/R/plot_methylation.R
@@ -99,7 +99,7 @@ plot_methylation_internal <- function(
 
     # add auxiliary elements and style
     p +
-        ggplot2::geom_rug(aes(col = NULL), sides = "b") +
+        ggplot2::geom_rug(aes(col = NULL), sides = "b", outside = TRUE) +
         ggplot2::ggtitle(title) +
         ggplot2::xlab(chr) +
         ggplot2::scale_y_continuous(


### PR DESCRIPTION
Problem: The rug tassels (within plot_methylation_internal function of plot_methylation.R) are inside the graph, which could hamper visibility when the statistics field exhibits zero or near-zero values

Solution: Bringing the rug tassels outside